### PR TITLE
Update linux-meson64-current.config for Waydroid support

### DIFF
--- a/config/kernel/linux-meson64-current.config
+++ b/config/kernel/linux-meson64-current.config
@@ -125,7 +125,8 @@ CONFIG_TASKSTATS=y
 CONFIG_TASK_DELAY_ACCT=y
 CONFIG_TASK_XACCT=y
 CONFIG_TASK_IO_ACCOUNTING=y
-# CONFIG_PSI is not set
+CONFIG_PSI=y
+# CONFIG_PSI_DEFAULT_DISABLED is not set
 # end of CPU/Task time and stats accounting
 
 CONFIG_CPU_ISOLATION=y
@@ -9210,7 +9211,11 @@ CONFIG_USB4_DMA_TEST=m
 #
 # Android
 #
-# CONFIG_ANDROID_BINDER_IPC is not set
+CONFIG_ASHMEM=y
+CONFIG_ANDROID_BINDER_IPC=y
+CONFIG_ANDROID_BINDERFS=y
+CONFIG_ANDROID_BINDER_DEVICES="binder,hwbinder,vndbinder,anbox-binder,anbox-hwbinder,anbox-vndbinder"
+# CONFIG_ANDROID_BINDER_IPC_SELFTEST is not set
 # end of Android
 
 # CONFIG_LIBNVDIMM is not set


### PR DESCRIPTION
# Description
added PSI, ashmem, binder, binderfs to kernel config on meson64 to make Waydroid work on Amlogic S9xx.

I just cherry-picked and copy/pasted changes from here:
https://github.com/armbian/build/pull/4806/


# How Has This Been Tested?
untested